### PR TITLE
Version 1.1.0 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ typings/
 
 # next.js build output
 .next
+
+# MacOSX folder level custom attributes  
+.DS_Store
+
+# output from running jsdoc
+docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0
 - Add jsdoc node module to this project for auto convertion of comments into well formated html docs - exactly like javadocs.
 - Document module using [jsdoc markup](http://usejsdoc.org/tags-returns.html)
+- Add input validation and accompanying unit tests.
 
 ## 1.0.2
 - Add test overage report.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 1.0.2
+- Add test overage report.
+
+## 1.0.1
+- Add unit testing with Jest.
+
+## 1.0.0
+- First release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+- Add jsdoc node module to this project for auto convertion of comments into well formated html docs - exactly like javadocs.
+- Document module using [jsdoc markup](http://usejsdoc.org/tags-returns.html)
+
 ## 1.0.2
 - Add test overage report.
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,39 @@
 # ebabel-distance
 Return the distance in 3D space from point "a" x, y, and z coordinates to point "b" x, y, and z coordinates.
 
-## Install
+## Instructions for Module Usage in your project/game
+
+### Install
 ```
 npm i --save ebabel-distance
 ```
 
-## Usage
+### Usage
 ```
 const distance = require('ebabel-distance');
 
 const result = distance([-4, 10, 3], [2, 3, 8])
 ```
 
-## Develop this module
+## Instructions for further development of this module i.e. ebabel-distance
+
+## Fork and clone repo, then start your new develop branch
+
+* fork repository on github.com
+* git clone 'fork repository'
+* git checkout -b develop
+
+### First step when developing this module
 ```
 npm install
 ```
 
-## Test this module
+### Before checking in code test this module 
 ```
 npm test
+```
+
+### Generate documentation for this module
+```
+npm run jsdoc
 ```

--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
-// Return the distance in 3D space from point "a" x, y, and z coordinates to point "b" x, y, and z coordinates.
+/**
+ * `distance`
+ * Calculate the distance in 3D space from point "a" x, y, and z coordinates to point "b" x, y, and z coordinates.
+ * @param {array} a - Array start position in 3D space e.g. [-10, 5.1, 3]
+ * @param {array} b - Array end position in 3D space e.g. [0, 15.1, -7]
+ * @returns {number} Distance between a and b.
+ */
 const distance = (a, b) => Math.sqrt(
   Math.pow((b[0] - a[0]), 2)
   + Math.pow((b[1] - a[1]), 2)

--- a/index.js
+++ b/index.js
@@ -1,14 +1,24 @@
+'use strict';
+
 /**
  * `distance`
- * Calculate the distance in 3D space from point "a" x, y, and z coordinates to point "b" x, y, and z coordinates.
- * @param {array} a - Array start position in 3D space e.g. [-10, 5.1, 3]
- * @param {array} b - Array end position in 3D space e.g. [0, 15.1, -7]
- * @returns {number} Distance between a and b.
+ * Calculate the distance in 3D space from point "i" x, y, and z coordinates to point "j" x, y, and z coordinates.
+ * @param {array} i - Array start position in 3D space e.g. [-10, 5.1, 3]
+ * @param {array} j - Array end position in 3D space e.g. [0, 15.1, -7]
+ * @returns {number} Distance between i and j.
  */
-const distance = (a, b) => Math.sqrt(
-  Math.pow((b[0] - a[0]), 2)
-  + Math.pow((b[1] - a[1]), 2)
-  + Math.pow((b[2] - a[2]), 2)
-);
+const distance = (i, j) => {  
+  if (!i && !j) throw new Error('Invalid input - need two sets coordinates.');
+  if (!j) throw new Error('Invalid input - only one set of coordinates.');
+  if (i.length !== 3) throw new Error('Input coordinates i should be an array of 3 numbers.');
+  if (j.length !== 3) throw new Error('Input coordinates j should be an array of 3 numbers.');
+  if (isNaN(i[0]) || isNaN(i[1]) || isNaN(i[2]) ) throw new Error('Invalid input i: should be numeric coordinates.');
+  if (isNaN(j[0]) || isNaN(j[1]) || isNaN(j[2]) ) throw new Error('Invalid input j: should be numeric coordinates.');
+
+  return Math.sqrt(
+    Math.pow((j[0] - i[0]), 2)
+    + Math.pow((j[1] - i[1]), 2)
+    + Math.pow((j[2] - i[2]), 2));
+}
 
 module.exports = distance;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ebabel-distance",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ebabel-distance",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -819,6 +819,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bluebird": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -927,6 +933,15 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
+    },
+    "catharsis": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+      "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+      "dev": true,
+      "requires": {
+        "underscore-contrib": "~0.3.0"
+      }
     },
     "chalk": {
       "version": "2.4.1",
@@ -3203,12 +3218,49 @@
         "esprima": "^4.0.0"
       }
     },
+    "js2xmlparser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+      "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+      "dev": true,
+      "requires": {
+        "xmlcreate": "^1.0.1"
+      }
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
+    },
+    "jsdoc": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
+      "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
+      "dev": true,
+      "requires": {
+        "babylon": "7.0.0-beta.19",
+        "bluebird": "~3.5.0",
+        "catharsis": "~0.8.9",
+        "escape-string-regexp": "~1.0.5",
+        "js2xmlparser": "~3.0.0",
+        "klaw": "~2.0.0",
+        "marked": "~0.3.6",
+        "mkdirp": "~0.5.1",
+        "requizzle": "~0.2.1",
+        "strip-json-comments": "~2.0.1",
+        "taffydb": "2.6.2",
+        "underscore": "~1.8.3"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.19",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+          "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+          "dev": true
+        }
+      }
     },
     "jsdom": {
       "version": "11.12.0",
@@ -3293,6 +3345,15 @@
       "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
+      }
+    },
+    "klaw": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+      "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
       }
     },
     "kleur": {
@@ -3409,6 +3470,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "dev": true
     },
     "math-random": {
       "version": "1.0.1",
@@ -4228,6 +4295,23 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "requizzle": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+      "dev": true,
+      "requires": {
+        "underscore": "~1.6.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
+        }
+      }
+    },
     "resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
@@ -4976,6 +5060,12 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -4989,6 +5079,12 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
+    },
+    "taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
     "test-exclude": {
@@ -5139,6 +5235,29 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
+        }
+      }
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
+    },
+    "underscore-contrib": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+      "dev": true,
+      "requires": {
+        "underscore": "1.6.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
         }
       }
     },
@@ -5438,6 +5557,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "xmlcreate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
+      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ebabel-distance",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Return the distance in 3D space from point \"a\" x, y, and z coordinates to point \"b\" x, y, and z coordinates.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "ebabel-distance",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Return the distance in 3D space from point \"a\" x, y, and z coordinates to point \"b\" x, y, and z coordinates.",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Return the distance in 3D space from point \"a\" x, y, and z coordinates to point \"b\" x, y, and z coordinates.",
   "main": "index.js",
   "scripts": {
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "jsdoc": "node ./node_modules/.bin/jsdoc -d docs ./index.js"
   },
   "repository": {
     "type": "git",
@@ -22,6 +23,7 @@
   },
   "homepage": "https://github.com/ebabel-eu/ebabel-distance#readme",
   "devDependencies": {
-    "jest": "^23.6.0"
+    "jest": "^23.6.0",
+    "jsdoc": "^3.5.5"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,10 +1,63 @@
 const distance = require('../index');
 
-test('distance measures accurately how far from a to b', () => {
-  const a = [0, 0, 0];
-  const b = [10, 0, 0];
+test('distance measures accurately how far from i to j', () => {
+  const i = [0, 0, 0];
+  const j = [10, 0, 0];
 
-  const result = distance(a, b);
-
+  const result = distance(i, j);
   expect(result).toBe(10);
+});
+
+test('handle a mixture of 2D and 3D inputs', () => {
+  const i = [0, 0];
+  const j = [10, 0, 0];
+
+  expect(() => distance(i, j)).toThrowError('Input coordinates i should be an array of 3 numbers.');
+});
+
+test('handle a mixture of 3D and 2D inputs', () => {
+  const i = [0, 0, 0];
+  const j = [0, 0];
+
+  expect(() => distance(i, j)).toThrowError('Input coordinates j should be an array of 3 numbers.');
+});
+
+test('handle 3D inputs but with non-numeric corruption in i', () => {
+  const i = [0, 0, 'f'];
+  const j = [10, 0, 0];
+
+  expect(() => distance(i, j)).toThrowError('Invalid input i: should be numeric coordinates.');
+});
+
+test('handle 3D inputs but with non-numeric corruption in j', () => {
+  const i = [0, 0, 12];
+  const j = [10, '7i', 0];
+
+  expect(() => distance(i, j)).toThrowError('Invalid input j: should be numeric coordinates.');
+});
+
+test('handle 3D inputs with implicit converstion', () => {
+  const i = [0, 0, 0];
+  const j = [0, '42', 0];
+
+  const answer = distance(i, j);
+  expect(answer).toBe(42);
+});
+
+
+test('handle input missing entirely', () => {
+  expect(() => distance()).toThrowError('Invalid input - need two sets coordinates.');
+});
+
+test('handle single missing input', () => {
+  const i = [0, 0, 0];
+  
+  expect(() => distance(i)).toThrowError('Invalid input - only one set of coordinates.');
+});
+
+// note this test is equivalent to the previous one i.e. here i and j represent the first and only set of coordinates
+test('handle single missing input - duplicate test i vs j', () => {
+  const j = [0, 0, 0];
+
+  expect(() => distance(j)).toThrowError('Invalid input - only one set of coordinates.');
 });


### PR DESCRIPTION
- Add jsdoc node module to this project for auto conversion of comments into well-formated html docs - exactly like javadocs.
- Document module using [jsdoc markup](http://usejsdoc.org/tags-returns.html)
- Add input validation and accompanying unit tests.